### PR TITLE
Document central types and improve readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.1
+
+### Fixed
+
+- Add Documentation of central types to improve package usability.
+
 ## 1.0.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 # SwaggerUI Handler For Gin
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/DEXPRO-Solutions-GmbH/swaggerui.svg)](https://pkg.go.dev/github.com/DEXPRO-Solutions-GmbH/swaggerui)
+[![Go Report Card](https://goreportcard.com/badge/github.com/DEXPRO-Solutions-GmbH/swaggerui)](https://goreportcard.com/report/github.com/DEXPRO-Solutions-GmbH/swaggerui)
+
 This project implements a gin Handler which allows you to
 expose your OpenAPI spec via SwaggerUI.
+
+## Installing
+
+```shell
+go get github.com/DEXPRO-Solutions-GmbH/swaggerui
+```


### PR DESCRIPTION
This adds some documentation to existing types to improve usability.

This also makes the readme a bit nicer.