### PR TITLE
Add /swaggerui as alternative to swagger-ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
--
+- Add `/swaggerui` as alternative to `swagger-ui`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Next
+
+### Added
+
+-
+
+### Fixed
+
+- 
+
 ## 1.0.1
 
 ### Fixed

--- a/handler.go
+++ b/handler.go
@@ -56,6 +56,7 @@ func (handler *Handler) Register(router gin.IRoutes) {
 	//router.GET("/openapi.yml", handler.GetSpec)
 	router.GET("/openapi.yml", handler.GetSpec)
 	router.StaticFS("/swagger-ui", handler.FS)
+	router.StaticFS("/swaggerui", handler.FS)
 }
 
 // Option objects used to construct Handler objects.


### PR DESCRIPTION
This PR closes #3 

Users will typically try to open "swaggerui" in their browser, not "swagger-ui"