### PR TITLE
Add WithReplaceServerUrls option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add `/swaggerui` as alternative to `swagger-ui`
+- Add `WithReplaceServerUrls` option as alternative to `WithAddServerUrls`
 
 ### Fixed
 

--- a/spec.go
+++ b/spec.go
@@ -81,6 +81,11 @@ func (spec Spec) AddServerUrl(serverUrl string) {
 	spec["servers"] = specServers
 }
 
+// RemoveServerURLs removes all server urls and removes the servers key.
+func (spec Spec) RemoveServerURLs() {
+	delete(spec, "servers")
+}
+
 func ParseSpecYAML(raw []byte) (Spec, error) {
 	var spec Spec
 	if err := yaml.Unmarshal(raw, &spec); err != nil {

--- a/spec_test.go
+++ b/spec_test.go
@@ -77,3 +77,13 @@ func TestParseSpec(t *testing.T) {
 		assert.IsType(t, Spec{}, spec["info"], "child properties of spec have unexpected type")
 	})
 }
+
+func TestSpec_RemoveServerURLs(t *testing.T) {
+	spec, err := ParseSpecYAML(exampleSpec)
+	require.NoError(t, err)
+	require.Len(t, spec["servers"], 1)
+
+	spec.RemoveServerURLs()
+	_, exists := spec["servers"]
+	assert.False(t, exists, "servers property should be removed")
+}


### PR DESCRIPTION
This closes #4 because it allows users to replace the existing values of `spec.servers`.