### PR TITLE
Fix swaggerui path by redirecting to swagger-ui

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -53,10 +53,11 @@ func NewHandler(specYML []byte, opts ...Option) (*Handler, error) {
 
 // Register is used to register the Handler on a gin router.
 func (handler *Handler) Register(router gin.IRoutes) {
-	//router.GET("/openapi.yml", handler.GetSpec)
 	router.GET("/openapi.yml", handler.GetSpec)
 	router.StaticFS("/swagger-ui", handler.FS)
-	router.StaticFS("/swaggerui", handler.FS)
+	router.GET("/swaggerui", func(ctx *gin.Context) {
+		ctx.Redirect(http.StatusPermanentRedirect, "/swagger-ui")
+	})
 }
 
 // Option objects used to construct Handler objects.


### PR DESCRIPTION
Closing #10 

This is the simplest fix for the linked bug. SwaggerUI is not intended to be run on paths other that `swagger-ui` at least not without modifying `dist/swagger-initializer.js`.

I think it is a wise choice not to modify that file as that keeps maintenance low. If we changed that we would have to apply those changes every time we update swaggerUI. That is of course possible and _would_ be simpler when using git patch files but in this PR I'd like to go the simple route.